### PR TITLE
stop using lukechampine/randMap

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -15,25 +15,6 @@
   version = "v0.2.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:374de5616a7287bd49d888888422f76321b2f84ae69544b4b040c2009704e3a4"
-  name = "github.com/lukechampine/randmap"
-  packages = [
-    ".",
-    "perm",
-  ]
-  pruneopts = "UT"
-  revision = "9e3c222d041309b34f799305d561f5adf3fc0181"
-
-[[projects]]
-  branch = "master"
-  digest = "1:130cefe87d7eeefc824978dcb78e35672d4c49a11f25c153fbf0cfd952756fa3"
-  name = "github.com/minio/blake2b-simd"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "3f5f724cb5b182a5c278d6d3d55b40e7f8c2efb4"
-
-[[projects]]
   digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
@@ -59,7 +40,6 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/lukechampine/randmap",
     "github.com/pkg/errors",
     "gotest.tools/assert",
   ]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,52 +2,66 @@
 
 
 [[projects]]
+  digest = "1:2e3c336fc7fde5c984d2841455a658a6d626450b1754a854b3b32e7a8f49a07a"
   name = "github.com/google/go-cmp"
   packages = [
     "cmp",
     "cmp/internal/diff",
     "cmp/internal/function",
-    "cmp/internal/value"
+    "cmp/internal/value",
   ]
+  pruneopts = "UT"
   revision = "3af367b6b30c263d47e8895973edcca9a49cf029"
   version = "v0.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:374de5616a7287bd49d888888422f76321b2f84ae69544b4b040c2009704e3a4"
   name = "github.com/lukechampine/randmap"
   packages = [
     ".",
-    "perm"
+    "perm",
   ]
+  pruneopts = "UT"
   revision = "9e3c222d041309b34f799305d561f5adf3fc0181"
 
 [[projects]]
   branch = "master"
+  digest = "1:130cefe87d7eeefc824978dcb78e35672d4c49a11f25c153fbf0cfd952756fa3"
   name = "github.com/minio/blake2b-simd"
   packages = ["."]
+  pruneopts = "UT"
   revision = "3f5f724cb5b182a5c278d6d3d55b40e7f8c2efb4"
 
 [[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = "UT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:225f565dc88a02cebe329d3a49d0ca125789091af952a5cc4fde6312c34ce44d"
   name = "gotest.tools"
   packages = [
     "assert",
     "assert/cmp",
     "internal/difflib",
     "internal/format",
-    "internal/source"
+    "internal/source",
   ]
+  pruneopts = "UT"
   revision = "b6e20af1ed078cd01a6413b734051a292450b4cb"
   version = "v2.1.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9af09f7d16cc64962739b21d075ee252de67b801c7260cf022604494006d15c2"
+  input-imports = [
+    "github.com/lukechampine/randmap",
+    "github.com/pkg/errors",
+    "gotest.tools/assert",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/bm/bm_test.go
+++ b/bm/bm_test.go
@@ -1,15 +1,12 @@
 package bm_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/mathetake/intergo"
-
-	"gotest.tools/assert"
-
-	"fmt"
-
 	"github.com/mathetake/intergo/bm"
+	"gotest.tools/assert"
 )
 
 type tRanking []int

--- a/bm/export_test.go
+++ b/bm/export_test.go
@@ -1,1 +1,0 @@
-package bm

--- a/intergo_test.go
+++ b/intergo_test.go
@@ -2,9 +2,8 @@
 package intergo_test
 
 import (
-	"testing"
-
 	"fmt"
+	"testing"
 
 	"github.com/mathetake/intergo"
 	"github.com/mathetake/intergo/bm"

--- a/om/om.go
+++ b/om/om.go
@@ -2,9 +2,8 @@ package om
 
 import (
 	"math/rand"
-	"time"
-
 	"sync"
+	"time"
 
 	"github.com/mathetake/intergo"
 	"github.com/pkg/errors"

--- a/om/om_test.go
+++ b/om/om_test.go
@@ -1,14 +1,12 @@
 package om_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/mathetake/intergo"
 	"github.com/mathetake/intergo/om"
-
 	"gotest.tools/assert"
-
-	"fmt"
 )
 
 type tRanking []int

--- a/tdm/export_test.go
+++ b/tdm/export_test.go
@@ -1,5 +1,5 @@
 package tdm
 
-func ExportedGetRandomKey(m map[int]interface{}) int {
-	return getRandomKey(m)
+func ExportedPopRandomIdx(target []int) (int, []int) {
+	return popRandomIdx(target)
 }

--- a/tdm/tdm.go
+++ b/tdm/tdm.go
@@ -1,8 +1,9 @@
 package tdm
 
 import (
-	"github.com/mathetake/intergo"
 	"math/rand"
+
+	"github.com/mathetake/intergo"
 )
 
 type TeamDraftMultileaving struct{}
@@ -57,7 +58,7 @@ func (tdm *TeamDraftMultileaving) GetInterleavedRanking(num int, rks ...intergo.
 
 		if len(minRks) == 0 {
 			// restore the targets
-			minRks = make([]int, 0, numR)
+			minRks = make([]int, 0, numR-len(usedUpRks))
 			for i := 0; i < numR; i++ {
 				if !usedUpRks[i] {
 					minRks = append(minRks, i)
@@ -76,7 +77,7 @@ func popRandomIdx(target []int) (int, []int) {
 	selectedIDx := rand.Intn(len(target))
 	selected := target[selectedIDx]
 
-	popped := make([]int, 0, len(target) -1)
+	popped := make([]int, 0, len(target)-1)
 
 	for i, idx := range target {
 		if i < selectedIDx {

--- a/tdm/tdm.go
+++ b/tdm/tdm.go
@@ -1,8 +1,8 @@
 package tdm
 
 import (
-	"github.com/lukechampine/randmap"
 	"github.com/mathetake/intergo"
+	"math/rand"
 )
 
 type TeamDraftMultileaving struct{}
@@ -17,11 +17,12 @@ func (tdm *TeamDraftMultileaving) GetInterleavedRanking(num int, rks ...intergo.
 	sIDs := map[interface{}]interface{}{}
 
 	// minRks have rankings' index whose number of selected items is minimum
-	minRks := map[int]interface{}{}
+	minRks := make([]int, 0, numR)
+
 	// lastIdx has a last index of the indexed ranking
 	lastIdx := map[int]int{}
 	for i := 0; i < numR; i++ {
-		minRks[i] = true
+		minRks = append(minRks, i)
 		lastIdx[i] = 0
 	}
 
@@ -31,7 +32,8 @@ func (tdm *TeamDraftMultileaving) GetInterleavedRanking(num int, rks ...intergo.
 	for len(res) < num && len(usedUpRks) != numR {
 
 		// chose one ranking from keys of minRks
-		var selected = getRandomKey(minRks)
+		var selected int
+		selected, minRks = popRandomIdx(minRks)
 		var rk = rks[selected]
 
 		var bef = len(res)
@@ -53,14 +55,12 @@ func (tdm *TeamDraftMultileaving) GetInterleavedRanking(num int, rks ...intergo.
 			usedUpRks[selected] = true
 		}
 
-		// delete the selected ranking from minRks
-		delete(minRks, selected)
-
 		if len(minRks) == 0 {
 			// restore the targets
+			minRks = make([]int, 0, numR)
 			for i := 0; i < numR; i++ {
 				if !usedUpRks[i] {
-					minRks[i] = true
+					minRks = append(minRks, i)
 				}
 			}
 		}
@@ -68,7 +68,24 @@ func (tdm *TeamDraftMultileaving) GetInterleavedRanking(num int, rks ...intergo.
 	return res, nil
 }
 
-func getRandomKey(m map[int]interface{}) int {
-	k, _ := randmap.Key(m).(int)
-	return k
+func popRandomIdx(target []int) (int, []int) {
+	if len(target) == 1 {
+		return target[0], []int{}
+	}
+
+	selectedIDx := rand.Intn(len(target))
+	selected := target[selectedIDx]
+
+	popped := make([]int, 0, len(target) -1)
+
+	for i, idx := range target {
+		if i < selectedIDx {
+			popped = append(popped, idx)
+		} else if i == selectedIDx {
+			continue
+		} else {
+			popped = append(popped, idx)
+		}
+	}
+	return selected, popped
 }

--- a/tdm/tdm_test.go
+++ b/tdm/tdm_test.go
@@ -1,14 +1,12 @@
 package tdm_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/mathetake/intergo"
 	"github.com/mathetake/intergo/tdm"
-
 	"gotest.tools/assert"
-
-	"fmt"
 )
 
 type tRanking []int

--- a/tdm/tdm_test.go
+++ b/tdm/tdm_test.go
@@ -123,34 +123,37 @@ func TestTeamDraftMultileaving(t *testing.T) {
 	}
 }
 
-func TestGetRandomKey(t *testing.T) {
-	tc := struct {
-		numCandidate int
-		numSelection int
-		threshold    float64
+func TestPopRandomIdx(t *testing.T) {
+	for i, cc := range []struct {
+		target []int
+		expLen int
 	}{
-		numCandidate: 10,
-		numSelection: 1000000,
-		threshold:    10e-4,
-	}
-	input := map[int]interface{}{}
-	for i := 0; i < tc.numCandidate; i++ {
-		input[i] = true
-	}
+		{
+			target: []int{1},
+			expLen: 0,
+		},
+		{
+			target: []int{1, 2, 3, 4},
+			expLen: 3,
+		},
+		{
+			target: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			expLen: 9,
+		},
+	} {
+		c := cc
+		t.Run(fmt.Sprintf("%d-th case", i), func(t *testing.T) {
+			actualS, actualP := tdm.ExportedPopRandomIdx(c.target)
+			assert.Equal(t, c.expLen, len(actualP))
 
-	chosenRatio := map[int]float64{}
+			isIncluded := false
+			for _, actual := range actualP {
+				if actual == actualS {
+					isIncluded = true
+				}
+			}
 
-	for i := 0; i < tc.numSelection; i++ {
-		chosenRatio[tdm.ExportedGetRandomKey(input)] += 1 / float64(tc.numSelection)
-	}
-
-	t.Log(chosenRatio)
-
-	for _, v := range chosenRatio {
-		diff := v - 1/float64(tc.numCandidate)
-		if diff < 0 {
-			diff = -diff
-		}
-		assert.Equal(t, true, diff < tc.threshold)
+			assert.Equal(t, false, isIncluded)
+		})
 	}
 }


### PR DESCRIPTION
This PR resolves #5 .
Since lukechampine/randMap seem to be wrong with Go 1.11+, I decided not use randMap.

The following is the bench mark result for comparing our new implementation to the old one on Go 1.10 environment.
As you see, it actually speed up Team Draft Multileaving 🤣 🤣 🤣 🤣 

## without randMap
```
inputRankingNum: 2, inputRankingItemNum: 10, interleavedRankingItemNum: 5
BenchmarkMultileaving/[[0-th_bench_on_Team_Draft_Multileaving]]-2         	 1000000	      1162 ns/op

inputRankingNum: 2, inputRankingItemNum: 200, interleavedRankingItemNum: 50
BenchmarkMultileaving/[[1-th_bench_on_Team_Draft_Multileaving]]-2                              	   50000	     22018 ns/op

inputRankingNum: 2, inputRankingItemNum: 200, interleavedRankingItemNum: 200
BenchmarkMultileaving/[[2-th_bench_on_Team_Draft_Multileaving]]-2                              	   20000	     98496 ns/op

inputRankingNum: 2, inputRankingItemNum: 1000, interleavedRankingItemNum: 200
BenchmarkMultileaving/[[3-th_bench_on_Team_Draft_Multileaving]]-2                              	   20000	     72706 ns/op

inputRankingNum: 10, inputRankingItemNum: 10, interleavedRankingItemNum: 5
BenchmarkMultileaving/[[0-th_bench_on_Team_Draft_Multileaving]]#01-2                           	  500000	      2206 ns/op

inputRankingNum: 10, inputRankingItemNum: 200, interleavedRankingItemNum: 50
BenchmarkMultileaving/[[1-th_bench_on_Team_Draft_Multileaving]]#01-2                           	   50000	     22845 ns/op

inputRankingNum: 10, inputRankingItemNum: 200, interleavedRankingItemNum: 200
BenchmarkMultileaving/[[2-th_bench_on_Team_Draft_Multileaving]]#01-2                           	   10000	    126418 ns/op

inputRankingNum: 10, inputRankingItemNum: 1000, interleavedRankingItemNum: 200
BenchmarkMultileaving/[[3-th_bench_on_Team_Draft_Multileaving]]#01-2                           	   10000	    119141 ns/op

inputRankingNum: 50, inputRankingItemNum: 10, interleavedRankingItemNum: 5
BenchmarkMultileaving/[[0-th_bench_on_Team_Draft_Multileaving]]#02-2                           	  100000	     13028 ns/op

inputRankingNum: 50, inputRankingItemNum: 200, interleavedRankingItemNum: 50
BenchmarkMultileaving/[[1-th_bench_on_Team_Draft_Multileaving]]#02-2                           	   30000	     43127 ns/op

inputRankingNum: 50, inputRankingItemNum: 200, interleavedRankingItemNum: 200
BenchmarkMultileaving/[[2-th_bench_on_Team_Draft_Multileaving]]#02-2                           	   10000	    166655 ns/op

inputRankingNum: 50, inputRankingItemNum: 1000, interleavedRankingItemNum: 200
BenchmarkMultileaving/[[3-th_bench_on_Team_Draft_Multileaving]]#02-2                           	   10000	    182647 ns/op

inputRankingNum: 100, inputRankingItemNum: 10, interleavedRankingItemNum: 5
BenchmarkMultileaving/[[0-th_bench_on_Team_Draft_Multileaving]]#03-2                           	  100000	     22664 ns/op

inputRankingNum: 100, inputRankingItemNum: 200, interleavedRankingItemNum: 50
BenchmarkMultileaving/[[1-th_bench_on_Team_Draft_Multileaving]]#03-2                           	   20000	     78914 ns/op

inputRankingNum: 100, inputRankingItemNum: 200, interleavedRankingItemNum: 200
BenchmarkMultileaving/[[2-th_bench_on_Team_Draft_Multileaving]]#03-2                           	   10000	    205680 ns/op


inputRankingNum: 100, inputRankingItemNum: 1000, interleavedRankingItemNum: 200
BenchmarkMultileaving/[[3-th_bench_on_Team_Draft_Multileaving]]#03-2                           	    5000	    277190 ns/op
```

## with randMap
```
inputRankingNum: 2, inputRankingItemNum: 10, interleavedRankingItemNum: 5
BenchmarkMultileaving/[[0-th_bench_on_Team_Draft_Multileaving]]-2         	  200000	     10515 ns/op

inputRankingNum: 2, inputRankingItemNum: 200, interleavedRankingItemNum: 50
BenchmarkMultileaving/[[1-th_bench_on_Team_Draft_Multileaving]]-2                              	   20000	     90303 ns/op

inputRankingNum: 2, inputRankingItemNum: 200, interleavedRankingItemNum: 200
BenchmarkMultileaving/[[2-th_bench_on_Team_Draft_Multileaving]]-2                              	    5000	    373869 ns/op

inputRankingNum: 2, inputRankingItemNum: 1000, interleavedRankingItemNum: 200
BenchmarkMultileaving/[[3-th_bench_on_Team_Draft_Multileaving]]-2                              	    3000	    366139 ns/op

inputRankingNum: 10, inputRankingItemNum: 10, interleavedRankingItemNum: 5
BenchmarkMultileaving/[[0-th_bench_on_Team_Draft_Multileaving]]#01-2                           	  100000	     18770 ns/op

inputRankingNum: 10, inputRankingItemNum: 200, interleavedRankingItemNum: 50
BenchmarkMultileaving/[[1-th_bench_on_Team_Draft_Multileaving]]#01-2                           	   10000	    153734 ns/op

inputRankingNum: 10, inputRankingItemNum: 200, interleavedRankingItemNum: 200
BenchmarkMultileaving/[[2-th_bench_on_Team_Draft_Multileaving]]#01-2                           	    2000	    662568 ns/op

inputRankingNum: 10, inputRankingItemNum: 1000, interleavedRankingItemNum: 200
BenchmarkMultileaving/[[3-th_bench_on_Team_Draft_Multileaving]]#01-2                           	    2000	    590230 ns/op

inputRankingNum: 50, inputRankingItemNum: 10, interleavedRankingItemNum: 5
BenchmarkMultileaving/[[0-th_bench_on_Team_Draft_Multileaving]]#02-2                           	   30000	     48804 ns/op

inputRankingNum: 50, inputRankingItemNum: 200, interleavedRankingItemNum: 50
BenchmarkMultileaving/[[1-th_bench_on_Team_Draft_Multileaving]]#02-2                           	    5000	    275238 ns/op

inputRankingNum: 50, inputRankingItemNum: 200, interleavedRankingItemNum: 200
BenchmarkMultileaving/[[2-th_bench_on_Team_Draft_Multileaving]]#02-2                           	    2000	   1157164 ns/op

inputRankingNum: 50, inputRankingItemNum: 1000, interleavedRankingItemNum: 200
BenchmarkMultileaving/[[3-th_bench_on_Team_Draft_Multileaving]]#02-2                           	    1000	   1290535 ns/op

inputRankingNum: 100, inputRankingItemNum: 10, interleavedRankingItemNum: 5
BenchmarkMultileaving/[[0-th_bench_on_Team_Draft_Multileaving]]#03-2                           	   30000	     56903 ns/op

inputRankingNum: 100, inputRankingItemNum: 200, interleavedRankingItemNum: 50
BenchmarkMultileaving/[[1-th_bench_on_Team_Draft_Multileaving]]#03-2                           	    3000	    375085 ns/op

inputRankingNum: 100, inputRankingItemNum: 200, interleavedRankingItemNum: 200
BenchmarkMultileaving/[[2-th_bench_on_Team_Draft_Multileaving]]#03-2                           	    1000	   1111393 ns/op

inputRankingNum: 100, inputRankingItemNum: 1000, interleavedRankingItemNum: 200
BenchmarkMultileaving/[[3-th_bench_on_Team_Draft_Multileaving]]#03-2                           	    2000	   1234889 ns/op
```
